### PR TITLE
Allow connections from ELB to EC2 instance listen port using AWS

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -9,7 +9,21 @@ for the domain/fqdn you wish to use on the ELB, as well as pre-existing IGW subn
 
 Future version of this charm will offer lets-encrypt cert creation/acquisition capability.
 
-# Deployment Example
+When you create a load balancer in a VPC, you must choose whether to make it an internal load balancer 
+or an Internet-facing load balancer.
+
+The nodes of an Internet-facing load balancer have public IP addresses. The DNS name of an Internet-facing 
+load balancer is publicly resolvable to the public IP addresses of the nodes. Therefore, Internet-facing 
+load balancers can route requests from clients over the Internet. For more information, 
+see Internet-Facing Classic Load Balancers.
+
+The nodes of an internal load balancer have only private IP addresses. The DNS name of an internal load balancer 
+is publicly resolvable to the private IP addresses of the nodes. Therefore, internal load balancers can only route
+ requests from clients with access to the VPC for the load balancer.
+ 
+It is recommended to use internal load balancer for services, which shouldn't be exposed publicly. 
+
+# Deployment example using Internet-facing (default) ELB type
 ```bash
 # Create the model and network space
 # (I often use a "nat" space that includes subnets that use a routing table that points 0.0.0.0/0 -> nat-gw)
@@ -57,6 +71,45 @@ unit-aws-elb-17:
 ```
 
 Following this you need to create/update an CNAME record to point at the FQDN of the ELB before you will be able to successfully access the web endpoint.
+
+# Deployment example using Internal ELB type
+
+When you use internal type ELB, you don't have to expose your juju application: `juju expose`.
+Your application is available only inside your VPC. You can also launch your internal 
+application EC2 instances without public IP assigned by configuring VPC subnets with 
+`Auto-assign public IPv4 address` option disabled and assign your juju application 
+machines to defined spaces (internal subnets).
+
+```bash
+# Create the model and network space (you can use existing model)
+
+juju add-model aws-elb-testing aws/us-west-2
+# create internal-nat space
+juju add-space internal-nat 172.31.102.0/24 172.31.103.0/24 172.31.104.0/24
+```
+
+```bash
+# Deploy the 2 primary charms and the subordinate
+juju deploy cs:~containers/aws-integrator-5
+juju deploy cs:~omnivector/aws-elb
+
+# deploy your internal service and setup internal subnets only EC2 instances
+juju deploy ./flask-internal --constraints "spaces=internal-nat"
+
+# Trust, config, and make relations
+# (The aws-elb charm will block until the 'subnets')
+juju trust aws-integrator
+juju relate aws-integrator aws-elb
+
+# set ELB internal type, ELB listen port and internal subnet ids (must pre-exist in aws)
+juju config aws-elb scheme=internal
+juju config aws-elb listener-raw-port=8080
+juju config aws-elb subnets="subnet-1de11955,subnet-50b0f336,subnet-7128282a"
+
+juju relate aws-elb flask-internal
+```
+After the ELB is [successfully created], you can use the action `get-elb-dns` 
+(see example above from Internet-type deployment example). ELB internal type expose service using private IP address, so the FQDN of the ELB is only reachable inside your VPC.
 
 ### Copyright
 * James Beedy (c) 2018 <jamesbeedy@gmail.com>

--- a/src/reactive/aws_elb.py
+++ b/src/reactive/aws_elb.py
@@ -38,7 +38,7 @@ from charms.layer.aws_elb import (
     get_health_by_target,
     get_targets,
     get_targets_health,
-    register_target,
+    register_target, authorize_elb_security_group_ingress, revoke_security_group_ingress,
 )
 
 
@@ -272,12 +272,21 @@ def register_initial_targets():
     endpoint = endpoint_from_flag('endpoint.aws-elb.available')
     units_data = endpoint.list_unit_data()
     status_set('maintenance', "Registering initial targets")
+    security_group_id = leader_get('security_group_id')
+    instance_port = int(leader_get('instance_port'))
     for unit_data in units_data:
         register_target(
            target_group_arn=leader_get('tgt_grp_arn'),
            instance_id=unit_data['instance_id'],
            region_name=leader_get('aws_region')
         )
+        if security_group_id:
+            authorize_elb_security_group_ingress(
+                instance_id=unit_data['instance_id'],
+                instance_port=instance_port,
+                elb_security_group_id=security_group_id,
+                region_name=leader_get('aws_region')
+            )
     status_set('active', "{} available".format(leader_get('elb_name')))
     set_flag('initial.targets.registered')
     update_target_health(endpoint)
@@ -293,6 +302,8 @@ def register_subsequent_targets():
         target_group_arn=leader_get('tgt_grp_arn'),
         region_name=leader_get('aws_region')
     ))
+    security_group_id = leader_get('security_group_id')
+    instance_port = int(leader_get('instance_port'))
 
     for unit_data in units_data:
         register_target(
@@ -300,6 +311,13 @@ def register_subsequent_targets():
            instance_id=unit_data['instance_id'],
            region_name=leader_get('aws_region')
         )
+        if security_group_id:
+            authorize_elb_security_group_ingress(
+                instance_id=unit_data['instance_id'],
+                instance_port=instance_port,
+                elb_security_group_id=security_group_id,
+                region_name=leader_get('aws_region')
+            )
         unmatched_targets.discard(unit_data['instance_id'])
         status_set('active',
                    "Registered {} with tgt_grp".format(
@@ -368,6 +386,7 @@ def remove_all_provisioned_aws_resources():
     elb_arn = leader_get('elb_arn')
     aws_region = leader_get('aws_region')
     security_group_id = leader_get('security_group_id')
+    port = int(leader_get('instance_port'))
 
     targets = get_targets(target_group_arn, aws_region)
 
@@ -391,6 +410,13 @@ def remove_all_provisioned_aws_resources():
     )
 
     if security_group_id:
+        for instance_id in targets:
+            revoke_security_group_ingress(
+                instance_id=instance_id,
+                instance_port=port,
+                elb_security_group_id=security_group_id,
+                region_name=leader_get('aws_region')
+            )
         delete_security_group(security_group_id, aws_region)
 
     # Unset leader values

--- a/src/reactive/aws_elb.py
+++ b/src/reactive/aws_elb.py
@@ -21,6 +21,7 @@ from charms.reactive import (
 )
 
 from charms.layer.aws_elb import (
+    authorize_elb_security_group_ingress,
     create_elb,
     create_listener,
     create_target_group,
@@ -38,7 +39,8 @@ from charms.layer.aws_elb import (
     get_health_by_target,
     get_targets,
     get_targets_health,
-    register_target, authorize_elb_security_group_ingress, revoke_security_group_ingress,
+    register_target,
+    revoke_security_group_ingress,
 )
 
 


### PR DESCRIPTION
Security Groups. ELB can use private EC2 IP address to do real requests
and health-check requests withouy exposing EC2 listen port to the Internet.
This is especially important when using ELB internal type for internal
services, which should not be exposed. Internal ELB uses only private IP
addresses, which are only available under VPC.